### PR TITLE
Add list feature to gpt-ui.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,14 +1554,15 @@ dependencies = [
 name = "gpt-ui"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "eframe",
  "egui",
- "home",
  "rand",
  "reqwest",
  "rfd",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1936,6 +1958,16 @@ dependencies = [
  "bitflags 2.5.0",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
 ]
 
 [[package]]
@@ -2343,12 +2375,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "libredox",
+ "libredox 0.0.2",
 ]
 
 [[package]]
@@ -2632,6 +2670,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox 0.1.3",
+ "thiserror",
 ]
 
 [[package]]
@@ -3404,6 +3453,16 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dirs = "5.0.1"
 eframe = "0.27.2"
 egui = "0.27.2"
-home = "0.5.9"
 rand = "0.8.5"
 reqwest = {version = "0.12.4", features = ["blocking", "charset"]}
 rfd = "0.14.1"
 serde = {version = "1.0.198", features = ["derive"]}
 serde_json = "1.0.116"
+uuid = {version = "1.9.1", features = ["v4", "serde"]}

--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -8,6 +8,7 @@ use std::{
 use rand::Rng;
 use reqwest::header;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::user_settings::ServerAddress;
 
@@ -34,7 +35,7 @@ pub struct Conversation {
 
     /// The text that is inside the users input field.
     /// Stored here so the input field wont clear if user wants to visit different conversations.
-    /// Also this is saved to file, so if program crashes or user quits the program, the input field text will be loaded from file.
+    /// Also this is saved to file, so if user quits the program, the input field text will be loaded from file.
     pub editor_text: String,
 
     /// [Conversation]'s filepath if it's saved
@@ -56,6 +57,9 @@ pub struct Conversation {
     /// Input text from the renaming window, to later put into title, or discard if cancelled.
     pub rename_text: String,
 
+    /// A unique id to conversations. Used to determine which list the conversation belongs to.
+    pub uuid: Uuid,
+
     max_tokens: i32,
     temperature: i32,
     seed: i32,
@@ -75,6 +79,7 @@ impl Default for Conversation {
             show_delete_conv_ui: false,
             delete: false,
             rename_text: "".to_owned(),
+            uuid: Uuid::new_v4(),
             max_tokens: 500,
             temperature: 0,
             seed: rand::thread_rng().gen_range(1000..=9999),
@@ -264,7 +269,7 @@ impl Message {
     }
 }
 
-// This is horrible too (Anrgy emoji).
+// This is horrible too (Angy emoji).
 // I have to make a new struct for serializing data to send to the AI.
 // I could have used the [Conversation] struct and serialize that, but when serializing fields that the AI doesn't need, it gets angry and errors.
 // I could have put a #[serde(skip_serialize)] attribute, but it would skip serializing fields I wanted to save to a json file.

--- a/src/list.rs
+++ b/src/list.rs
@@ -9,6 +9,12 @@ pub struct List {
     /// Vector containing the `Conversation`s in this list
     pub convs: Vec<Uuid>,
 
+    /// Is the list open or not
+    pub is_open: bool,
+
+    /// In which place is this list in the list of lists
+    pub order_index: usize,
+
     /// Mark the list for deletion
     pub delete: bool,
 }
@@ -18,6 +24,8 @@ impl List {
         List {
             list_name: name,
             convs: Vec::new(),
+            is_open: false,
+            order_index: 0,
             delete: false,
         }
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,29 @@
+use uuid::Uuid;
+pub struct List {
+    pub list_name: String,
+    pub convs: Vec<Uuid>,
+}
+
+impl List {
+    pub fn new(name: String) -> List {
+        List {
+            list_name: name,
+            convs: Vec::new(),
+        }
+    }
+
+    pub fn add(mut self, conv_uuid: Uuid) -> Self {
+        self.convs.push(conv_uuid);
+        self
+    }
+
+    pub fn remove(mut self, target_uuid: Uuid) -> Self {
+        for (i, conv_uuid) in self.convs.iter().enumerate() {
+            if *conv_uuid == target_uuid {
+                self.convs.remove(i);
+                break;
+            }
+        }
+        self
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,7 +1,16 @@
 use uuid::Uuid;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
 pub struct List {
+    /// The name of the list
     pub list_name: String,
+
+    /// Vector containing the `Conversation`s in this list
     pub convs: Vec<Uuid>,
+
+    /// Mark the list for deletion
+    pub delete: bool,
 }
 
 impl List {
@@ -9,6 +18,7 @@ impl List {
         List {
             list_name: name,
             convs: Vec::new(),
+            delete: false,
         }
     }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct List {
     /// The name of the list
     pub list_name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 mod conversation;
+mod list;
 mod save_load;
 mod ui_modules;
 mod user_settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ impl Default for GptUi {
 
 impl eframe::App for GptUi {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Delete conversation if it's marked for deletion
         for (i, conv) in self.conversations.clone().iter().enumerate() {
             if conv.delete {
                 if let Some(path) = &conv.file_path {
@@ -79,6 +80,13 @@ impl eframe::App for GptUi {
                 }
 
                 self.conversations.remove(i);
+            }
+        }
+
+        // Delete list if it's marked for deletion
+        for (i, list) in self.lists.clone().iter().enumerate() {
+            if list.delete {
+                self.lists.remove(i);
             }
         }
 

--- a/src/save_load/load.rs
+++ b/src/save_load/load.rs
@@ -1,6 +1,7 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use crate::conversation::Conversation;
+use crate::list::List;
 use crate::GptUi;
 
 pub fn load_all(ui_data: &mut GptUi) {
@@ -16,9 +17,34 @@ pub fn load_all(ui_data: &mut GptUi) {
 
     dir_contents.for_each(|file_result| {
         if let Ok(file) = file_result {
-            let conv = Conversation::load_from_file(file.path(), false);
+            if file.file_name() != "gpt-ui_lists.json" {
+                let conv = Conversation::load_from_file(file.path(), false);
 
-            ui_data.conversations.push(conv);
+                ui_data.conversations.push(conv);
+            }
         }
     });
+}
+
+pub fn load_lists(path: &PathBuf) -> Option<Vec<List>> {
+    let file_path = path.join("gpt-ui_lists.json");
+
+    if file_path.exists() {
+        match fs::read_to_string(file_path) {
+            Ok(file) => {
+                let lists: Vec<List> = serde_json::from_str(&file).unwrap();
+
+                Some(lists)
+            },
+
+            Err(e) => {
+                eprintln!("Failed to read lists file: {}", e);
+                None
+            }
+        }
+
+    } else {
+        println!("lists file does not exist");
+        None
+    }
 }

--- a/src/save_load/save.rs
+++ b/src/save_load/save.rs
@@ -81,3 +81,22 @@ pub fn save_conversation(mut conv: Conversation, ui_data: &mut GptUi) -> Result<
         }
     }
 }
+
+pub fn save_lists(ui_data: &mut GptUi) {
+    let save_path = ui_data.user_settings.conv_save_location.clone();
+
+    if let Ok(exists) = save_path.try_exists() {
+        if !exists {
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .create(&save_path)
+                .unwrap();
+        }
+    }
+
+    let json_data = serde_json::to_string(&ui_data.lists).unwrap();
+
+    if let Err(e) = fs::write(save_path.join("gpt-ui_lists.json"), json_data) {
+        eprintln!("Failed to save lists to file: {}", e);
+    }
+}

--- a/src/ui_modules/chat_hist_ui.rs
+++ b/src/ui_modules/chat_hist_ui.rs
@@ -1,3 +1,4 @@
+use crate::list::List;
 use crate::ui_modules::settings_ui::show_settings;
 use crate::Conversation;
 use crate::GptUi;
@@ -28,6 +29,12 @@ pub fn show_chat_history(ctx: &egui::Context, ui: &mut egui::Ui, ui_data: &mut G
                     }
                 }
             }
+
+            if ui.button("New List").clicked() {
+                ui_data.lists.push(List::new("New List".to_owned()));
+
+                println!("new list created!");
+            }
         });
 
         // Chat history scroll area
@@ -39,16 +46,31 @@ pub fn show_chat_history(ctx: &egui::Context, ui: &mut egui::Ui, ui_data: &mut G
             // Otherwise the scrollarea will go under the bottom panel.
             .max_height(ui.available_height() - 20.0)
             .show(ui, |ui| {
+
+                // List buttons
+                
+                let list_size = Vec2 {
+                    x: ui.available_width(),
+                    y: 20.0,
+                };
+            
+                for list in &ui_data.lists {
+                    if ui.add_sized(list_size, Button::new("List button")).clicked() {
+                        println!("List clicked. Name: {}", list.list_name);
+                    }
+                }
+
+                // Conversation buttons
                 // Counter for conversation index.
                 let mut conv_index = 0;
 
+                let conv_button_size = Vec2 {
+                    x: ui.available_width(),
+                    y: 40.0,
+                };
+
                 #[allow(clippy::explicit_counter_loop)]
                 for conv in &ui_data.conversations {
-                    let conv_button_size = Vec2 {
-                        x: ui.available_width(),
-                        y: 40.0,
-                    };
-
                     let button_text = if conv.title == "unnamed" {
                         format!("{}{}", conv.title, conv_index)
                     } else {

--- a/src/ui_modules/chat_hist_ui.rs
+++ b/src/ui_modules/chat_hist_ui.rs
@@ -3,6 +3,12 @@ use crate::ui_modules::settings_ui::show_settings;
 use crate::Conversation;
 use crate::GptUi;
 
+use egui::text::LayoutJob;
+use egui::Align;
+use egui::Color32;
+use egui::FontFamily;
+use egui::FontId;
+use egui::TextFormat;
 use egui::{Button, Vec2};
 
 /// Chat history UI
@@ -46,17 +52,44 @@ pub fn show_chat_history(ctx: &egui::Context, ui: &mut egui::Ui, ui_data: &mut G
             // Otherwise the scrollarea will go under the bottom panel.
             .max_height(ui.available_height() - 20.0)
             .show(ui, |ui| {
-
                 // List buttons
-                
+
                 let list_size = Vec2 {
                     x: ui.available_width(),
                     y: 20.0,
                 };
-            
-                for list in &ui_data.lists {
-                    if ui.add_sized(list_size, Button::new("List button")).clicked() {
+
+                for list in &mut ui_data.lists {
+                    let mut layout_job: LayoutJob;
+                    if list.is_open {
+                        layout_job = LayoutJob::simple_singleline(
+                            "<".to_owned(),
+                            FontId::new(14.0, FontFamily::Proportional),
+                            Color32::WHITE,
+                        );
+                    } else {
+                        layout_job = LayoutJob::simple_singleline(
+                            ">".to_owned(),
+                            FontId::new(14.0, FontFamily::Proportional),
+                            Color32::WHITE,
+                        );
+                    };
+
+                    layout_job.append(
+                        &list.list_name,
+                        0.0,
+                        TextFormat {
+                            font_id: FontId::new(14.0, FontFamily::Proportional),
+                            color: Color32::WHITE,
+                            ..Default::default()
+                        },
+                    );
+
+                    layout_job.halign = Align::LEFT;
+
+                    if ui.add_sized(list_size, Button::new(layout_job)).clicked() {
                         println!("List clicked. Name: {}", list.list_name);
+                        list.is_open = !list.is_open;
                     }
                 }
 

--- a/src/user_settings.rs
+++ b/src/user_settings.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{env, fs};
 
-use home::home_dir;
+use dirs::data_dir;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct UserSettings {
@@ -21,7 +21,7 @@ pub struct UserSettings {
 
 impl Default for UserSettings {
     fn default() -> Self {
-        let conv_save_dir = home_dir().unwrap().join("gpt-ui").join("conversations");
+        let conv_save_dir = data_dir().unwrap().join("gpt-ui").join("conversations");
         let address = ServerAddress::default();
 
         UserSettings {


### PR DESCRIPTION
### Adds lists feature to gpt-ui.
You can organize conversations into lists, so there is no one big list of conversations, where you can't find what you want.

Short list of things to implement, also works as a list of features this adds.

- [ ] Create collapsible lists.
- [ ] Move conversation into list with drag & drop.
- [ ] Rearrange lists (Lists will be above unlisted conversations).
- [ ] Fix clippy warnings

#### How are lists implemented?
Every conversation is given an UUID.
A list (in code) is a struct conatining it's name, Vec of conv UUIDs and the order index.

(Shortened conversation = conv)

When you move a conv into a list, the conv's UUID is put into the list's Vec of UUIDs. This way the program can keep track of which list a conv belongs to.